### PR TITLE
feat/redis 캐시 처리

### DIFF
--- a/coupon-core/src/main/java/com/example/couponcore/CouponCoreConfiguration.java
+++ b/coupon-core/src/main/java/com/example/couponcore/CouponCoreConfiguration.java
@@ -1,10 +1,12 @@
 package com.example.couponcore;
 
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableCaching
 @EnableJpaAuditing
 @Configuration
 @EnableAutoConfiguration

--- a/coupon-core/src/main/java/com/example/couponcore/configuration/CacheConfiguration.java
+++ b/coupon-core/src/main/java/com/example/couponcore/configuration/CacheConfiguration.java
@@ -1,0 +1,37 @@
+package com.example.couponcore.configuration;
+
+import java.time.Duration;
+import lombok.RequiredArgsConstructor;
+import org.springframework.cache.CacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@RequiredArgsConstructor
+public class CacheConfiguration {
+
+    private final RedisConnectionFactory redisConnectionFactory;
+
+    @Bean
+    public CacheManager cacheManager() {
+        RedisCacheConfiguration redisCacheConfiguration =
+                RedisCacheConfiguration.defaultCacheConfig()
+                        .serializeKeysWith(
+                                RedisSerializationContext.SerializationPair.fromSerializer(
+                                        new StringRedisSerializer()))
+                        .serializeValuesWith(
+                                RedisSerializationContext.SerializationPair.fromSerializer(
+                                        new GenericJackson2JsonRedisSerializer()))
+                        .entryTtl(Duration.ofMinutes(30));
+        return RedisCacheManager.RedisCacheManagerBuilder.fromConnectionFactory(redisConnectionFactory)
+                .cacheDefaults(redisCacheConfiguration)
+                .build();
+
+    }
+}

--- a/coupon-core/src/main/java/com/example/couponcore/repository/redis/dto/CouponRedisEntity.java
+++ b/coupon-core/src/main/java/com/example/couponcore/repository/redis/dto/CouponRedisEntity.java
@@ -1,0 +1,53 @@
+package com.example.couponcore.repository.redis.dto;
+
+import static com.example.couponcore.exception.ErrorCode.INVALID_COUPON_ISSUE_DATE;
+
+import com.example.couponcore.exception.CouponIssueException;
+import com.example.couponcore.exception.ErrorCode;
+import com.example.couponcore.model.Coupon;
+import com.example.couponcore.model.CouponType;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
+import java.time.LocalDateTime;
+
+//이 엔티티를 통해 유효성 검사를 한다. -> 기존 db조회 하던 것들을 캐시 조회로 변환
+public record CouponRedisEntity(
+        Long id,
+        CouponType couponType,
+        Integer totalQuantity,
+
+        @JsonSerialize(using = LocalDateTimeSerializer.class)
+        @JsonDeserialize(using = LocalDateTimeDeserializer.class)
+        LocalDateTime dateIssueStart,
+
+        @JsonSerialize(using = LocalDateTimeSerializer.class)
+        @JsonDeserialize(using = LocalDateTimeDeserializer.class)
+
+        LocalDateTime dateIssueEnd
+) {
+
+    public CouponRedisEntity(Coupon coupon) {
+        this(
+                coupon.getId(),
+                coupon.getCouponType(),
+                coupon.getTotalQuantity(),
+                coupon.getDateIssueStart(),
+                coupon.getDateIssueEnd()
+        );
+    }
+
+    private boolean availableIssueDate() {
+        LocalDateTime now = LocalDateTime.now();
+        return dateIssueStart.isBefore(now) && dateIssueEnd.isAfter(now);
+    }
+
+    public void checkIssuableCoupon() {
+        if (!availableIssueDate()) {
+            throw new CouponIssueException(INVALID_COUPON_ISSUE_DATE,
+                    " 발급 기간이 유효 하지 않음, couponId: %s, issueStart:%s, issueEnd:%s".formatted(id,
+                            dateIssueStart, dateIssueEnd));
+        }
+    }
+}

--- a/coupon-core/src/main/java/com/example/couponcore/service/CouponCacheService.java
+++ b/coupon-core/src/main/java/com/example/couponcore/service/CouponCacheService.java
@@ -1,0 +1,21 @@
+package com.example.couponcore.service;
+
+import com.example.couponcore.model.Coupon;
+import com.example.couponcore.repository.redis.dto.CouponRedisEntity;
+import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class CouponCacheService {
+
+    private final CouponIssueService couponIssueService;
+
+    @Cacheable(cacheNames = "coupon")
+    public CouponRedisEntity getCouponCache(long couponId) {
+        Coupon coupon = couponIssueService.findCoupon(couponId);
+        //위 coupon 을 cache 생성자에 전달
+        return new CouponRedisEntity(coupon);
+    }
+}

--- a/coupon-core/src/main/java/com/example/couponcore/service/CouponIssueRedisService.java
+++ b/coupon-core/src/main/java/com/example/couponcore/service/CouponIssueRedisService.java
@@ -1,8 +1,12 @@
 package com.example.couponcore.service;
 
+import static com.example.couponcore.exception.ErrorCode.DUPLICATED_COUPON_ISSUE;
+import static com.example.couponcore.exception.ErrorCode.INVALID_COUPON_ISSUE_QUANTITY;
 import static com.example.couponcore.util.CouponRedisUtil.getIssueRequestKey;
 
+import com.example.couponcore.exception.CouponIssueException;
 import com.example.couponcore.repository.redis.RedisRepository;
+import com.example.couponcore.repository.redis.dto.CouponRedisEntity;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -11,6 +15,20 @@ import org.springframework.stereotype.Service;
 public class CouponIssueRedisService {
 
     private final RedisRepository redisRepository;
+
+    public void checkCouponIssueQuantity(CouponRedisEntity couponRedisEntity,
+            long userId) {
+        Long id = couponRedisEntity.id();
+        Integer totalQuantity = couponRedisEntity.totalQuantity();
+        if (!availableTotalIssueQuantity(totalQuantity, id)) {
+            throw new CouponIssueException(INVALID_COUPON_ISSUE_QUANTITY,
+                    "발급 가능한 수량을 초과함. couponId: %s, userId : %s".formatted(id, userId));
+        }
+        if (!availableUserIssueQuantity(id, userId)) {
+            throw new CouponIssueException(DUPLICATED_COUPON_ISSUE,
+                    "이미 발급 요청이 처리 되었음. couponId: %s, userId : %s".formatted(id, userId));
+        }
+    }
 
     //중복 요청 검증
     public boolean availableUserIssueQuantity(long couponId, long userId) {


### PR DESCRIPTION
- 쿠폰 캐시를 통한 유효성 검증을 캐시 처리. 엔티티 필드를 가져오는 부분을 캐시 처리 ( Coupon coupon = couponIssueService.findCoupon(couponId); )
- set: 지정 couponId, userId 데이터
- string: 쿠폰 엔티티에 대한 캐시
- list: couponId, userId 
같은 userId 로 동일 쿠폰 발급 요청시, 발급큐(list) 에 적재되지 않음
- 락적용. 동시성 문제 해결